### PR TITLE
Rewritten parsers - ~3x performance increase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ logs
 *.log
 coverage
 node_modules
+.idea

--- a/.jshintignore
+++ b/.jshintignore
@@ -2,3 +2,5 @@ node_modules/**
 coverage/**
 **.md
 **.log
+.idea
+benchmark

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
     "freeze": true, // prohibit overwriting prototypes of native objects
     "maxdepth": 4,
     "latedef": true,
-    "maxparams": 3,
+    "maxparams": 4,
 
     // Environment options
     "node": true, // Enable globals available when code is running inside of the NodeJS runtime environment.

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+benchmark

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # redis-parser
 
-A high performance redis parser solution built for [node_redis](https://github.com/NodeRedis/node_redis) and [ioredis](https://github.com/ioredis/luin).
+A high performance redis parser solution built for [node_redis](https://github.com/NodeRedis/node_redis) and [ioredis](https://github.com/luin/ioredis).
 
 Generally all [RESP](http://redis.io/topics/protocol) data will be properly parsed by the parser.
 
@@ -95,31 +95,22 @@ var parser = new Parser({
 The [hiredis](https://github.com/redis/hiredis) parser is still the fasted parser for
 Node.js and therefor used as default in redis-parser if the hiredis parser is available.
 
-Otherwise the pure js NodeRedis parser is choosen that is almost as fast as the
+Otherwise the pure js NodeRedis parser is chosen that is almost as fast as the
 hiredis parser besides some situations in which it'll be a bit slower.
 
 ## Protocol errors
 
-To handle protocol errors (this is very unlikely to happen) gracefuly you should add the returnFatalError option, reject any still running command (they might have been processed properly but the reply is just wrong), destroy the socket and reconnect.
+To handle protocol errors (this is very unlikely to happen) gracefully you should add the returnFatalError option, reject any still running command (they might have been processed properly but the reply is just wrong), destroy the socket and reconnect.
 Otherwise a chunk might still contain partial data of a following command that was already processed properly but answered in the same chunk as the command that resulted in the protocol error.
 
 ## Contribute
 
 The js parser is already optimized but there are likely further optimizations possible.
-Besides running the tests you'll also have to run the change at least against the node_redis benchmark suite and post the improvement in the PR.
-If you want to write a own parser benchmark, that would also be great!
 
 ```
 npm install
 npm test
-
-# Run node_redis benchmark (let's guess you cloned node_redis in another folder)
-cd ../redis
-npm install
-npm run benchmark parser=javascript > old.log
-# Replace the changed parser in the node_modules
-npm run benchmark parser=javascript > new.log
-node benchmarks/diff_multi_bench_output.js old.log new.log > improvement.log
+npm run benchmark
 ```
 
 ## License

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,0 +1,138 @@
+var Benchmark = require('benchmark');
+var assert = require('assert');
+var suite = new Benchmark.Suite;
+
+var Parser = require('./../lib/parser');
+var ParserOLD = require('./old/parser');
+
+function returnError(error) {
+	// throw error; silent for err error perf test
+}
+
+function checkReply() {
+}
+
+var startBuffer = new Buffer('$100\r\nabcdefghij');
+var chunkBuffer = new Buffer('abcdefghijabcdefghijabcdefghij');
+var stringBuffer = new Buffer('+testing a simple string\r\n');
+var integerBuffer = new Buffer(':1237884\r\n');
+var errorBuffer = new Buffer('-Error ohnoesitbroke\r\n');
+var arrayBuffer = new Buffer('*1\r\n*1\r\n$1\r\na\r\n');
+var endBuffer = new Buffer('\r\n');
+
+var parserOld = new ParserOLD({
+	returnReply: checkReply,
+	returnError: returnError,
+	returnFatalError: returnError,
+	name: 'javascript'
+});
+
+var parserHiRedis = new Parser({
+	returnReply: checkReply,
+	returnError: returnError,
+	returnFatalError: returnError,
+	name: 'hiredis'
+});
+
+var parser = new Parser({
+	returnReply: checkReply,
+	returnError: returnError,
+	returnFatalError: returnError,
+	name: 'javascript'
+});
+
+// BULK STRINGS
+
+suite.add('OLD CODE: multiple chunks in a bulk string', function () {
+	parserOld.execute(startBuffer);
+	parserOld.execute(chunkBuffer);
+	parserOld.execute(chunkBuffer);
+	parserOld.execute(chunkBuffer);
+	parserOld.execute(endBuffer);
+});
+
+suite.add('HIREDIS: multiple chunks in a bulk string', function () {
+	parserHiRedis.execute(startBuffer);
+	parserHiRedis.execute(chunkBuffer);
+	parserHiRedis.execute(chunkBuffer);
+	parserHiRedis.execute(chunkBuffer);
+	parserHiRedis.execute(endBuffer);
+});
+
+suite.add('NEW CODE: multiple chunks in a bulk string', function () {
+	parser.execute(startBuffer);
+	parser.execute(chunkBuffer);
+	parser.execute(chunkBuffer);
+	parser.execute(chunkBuffer);
+	parser.execute(endBuffer);
+});
+
+// STRINGS
+
+suite.add('\nOLD CODE: + simple string', function () {
+	parserOld.execute(stringBuffer);
+});
+
+suite.add('HIREDIS: + simple string', function () {
+	parserHiRedis.execute(stringBuffer);
+});
+
+suite.add('NEW CODE: + simple string', function () {
+	parser.execute(stringBuffer);
+});
+
+// INTEGERS
+
+suite.add('\nOLD CODE: + integer', function () {
+	parserOld.execute(integerBuffer);
+});
+
+suite.add('HIREDIS: + integer', function () {
+	parserHiRedis.execute(integerBuffer);
+});
+
+suite.add('NEW CODE: + integer', function () {
+	parser.execute(integerBuffer);
+});
+
+// ARRAYS
+
+suite.add('\nOLD CODE: * array', function () {
+	parserOld.execute(arrayBuffer);
+});
+
+suite.add('HIREDIS: * array', function () {
+	parserHiRedis.execute(arrayBuffer);
+});
+
+suite.add('NEW CODE: * array', function () {
+	parser.execute(arrayBuffer);
+});
+
+
+// ERRORS
+
+suite.add('\nOLD CODE: * error', function () {
+	parserOld.execute(errorBuffer);
+});
+
+suite.add('HIREDIS: * error', function () {
+	parserHiRedis.execute(errorBuffer);
+});
+
+suite.add('NEW CODE: * error', function () {
+	parser.execute(errorBuffer);
+});
+
+
+// add listeners
+suite.on('cycle', function (event) {
+	console.log(String(event.target));
+});
+
+suite.on('complete', function () {
+	console.log('\n\nFastest is ' + this.filter('fastest').map('name'));
+});
+
+
+suite.run({delay:2, minSamples: 100 });

--- a/benchmark/old/hiredis.js
+++ b/benchmark/old/hiredis.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var hiredis = require('hiredis');
+
+function HiredisReplyParser(options) {
+    this.name = 'hiredis';
+    this.options = options;
+    this.reader = new hiredis.Reader(options);
+}
+
+HiredisReplyParser.prototype.parseData = function () {
+    try {
+        return this.reader.get();
+    } catch (err) {
+        // Protocol errors land here
+        // Reset the parser. Otherwise new commands can't be processed properly
+        this.reader = new hiredis.Reader(this.options);
+        this.returnFatalError(err);
+    }
+};
+
+HiredisReplyParser.prototype.execute = function (data) {
+    this.reader.feed(data);
+    var reply = this.parseData();
+
+    while (reply !== undefined) {
+        if (reply && reply.name === 'Error') {
+            this.returnError(reply);
+        } else {
+            this.returnReply(reply);
+        }
+        reply = this.parseData();
+    }
+};
+
+module.exports = HiredisReplyParser;

--- a/benchmark/old/javascript.js
+++ b/benchmark/old/javascript.js
@@ -1,0 +1,172 @@
+'use strict';
+
+function JavascriptReplyParser(options) {
+	this.name = 'javascript_old';
+	this.buffer = new Buffer(0);
+	this.offset = 0;
+	this.bigStrSize = 0;
+	this.chunksSize = 0;
+	this.buffers = [];
+	this.type = 0;
+	this.protocolError = false;
+	this.offsetCache = 0;
+	// If returnBuffers is active, all return values are returned as buffers besides numbers and errors
+	if (options.return_buffers) {
+		this.handleReply = function (start, end) {
+			return this.buffer.slice(start, end);
+		};
+	} else {
+		this.handleReply = function (start, end) {
+			return this.buffer.toString('utf-8', start, end);
+		};
+	}
+	// If stringNumbers is activated the parser always returns numbers as string
+	// This is important for big numbers (number > Math.pow(2, 53)) as js numbers are 64bit floating point numbers with reduced precision
+	if (options.string_numbers) {
+		this.handleNumbers = function (start, end) {
+			return this.buffer.toString('ascii', start, end);
+		};
+	} else {
+		this.handleNumbers = function (start, end) {
+			return +this.buffer.toString('ascii', start, end);
+		};
+	}
+}
+
+JavascriptReplyParser.prototype.parseResult = function (type) {
+	var start = 0,
+		end = 0,
+		packetHeader = 0,
+		reply;
+
+	if (type === 36) { // $
+		packetHeader = this.parseHeader();
+		// Packets with a size of -1 are considered null
+		if (packetHeader === -1) {
+			return null;
+		}
+		end = this.offset + packetHeader;
+		start = this.offset;
+		if (end + 2 > this.buffer.length) {
+			this.buffers.push(this.offsetCache === 0 ? this.buffer : this.buffer.slice(this.offsetCache));
+			this.chunksSize = this.buffers[0].length;
+			// Include the packetHeader delimiter
+			this.bigStrSize = packetHeader + 2;
+			throw new Error('Wait for more data.');
+		}
+		// Set the offset to after the delimiter
+		this.offset = end + 2;
+		return this.handleReply(start, end);
+	} else if (type === 58) { // :
+		// Up to the delimiter
+		end = this.packetEndOffset();
+		start = this.offset;
+		// Include the delimiter
+		this.offset = end + 2;
+		// Return the coerced numeric value
+		return this.handleNumbers(start, end);
+	} else if (type === 43) { // +
+		end = this.packetEndOffset();
+		start = this.offset;
+		this.offset = end + 2;
+		return this.handleReply(start, end);
+	} else if (type === 42) { // *
+		packetHeader = this.parseHeader();
+		if (packetHeader === -1) {
+			return null;
+		}
+		reply = [];
+		for (var i = 0; i < packetHeader; i++) {
+			if (this.offset >= this.buffer.length) {
+				throw new Error('Wait for more data.');
+			}
+			reply.push(this.parseResult(this.buffer[this.offset++]));
+		}
+		return reply;
+	} else if (type === 45) { // -
+		end = this.packetEndOffset();
+		start = this.offset;
+		this.offset = end + 2;
+		return new Error(this.buffer.toString('utf-8', start, end));
+	}
+};
+
+JavascriptReplyParser.prototype.execute = function (buffer) {
+	if (this.chunksSize !== 0) {
+		if (this.bigStrSize > this.chunksSize + buffer.length) {
+			this.buffers.push(buffer);
+			this.chunksSize += buffer.length;
+			return;
+		}
+		this.buffers.push(buffer);
+		this.buffer = Buffer.concat(this.buffers, this.chunksSize + buffer.length);
+		this.buffers = [];
+		this.bigStrSize = 0;
+		this.chunksSize = 0;
+	} else if (this.offset >= this.buffer.length) {
+		this.buffer = buffer;
+	} else {
+		this.buffer = Buffer.concat([this.buffer.slice(this.offset), buffer]);
+	}
+	this.offset = 0;
+	this.run();
+};
+
+JavascriptReplyParser.prototype.tryParsing = function () {
+	try {
+		return this.parseResult(this.type);
+	} catch (err) {
+		// Catch the error (not enough data), rewind if it's an array,
+		// and wait for the next packet to appear
+		this.offset = this.offsetCache;
+		// Indicate that there's no protocol error by resetting the type too
+		this.type = undefined;
+	}
+};
+
+JavascriptReplyParser.prototype.run = function () {
+	// Set a rewind point. If a failure occurs, wait for the next execute()/append() and try again
+	this.offsetCache = this.offset;
+	this.type = this.buffer[this.offset++];
+	var reply = this.tryParsing();
+
+	while (reply !== undefined) {
+		if (this.type === 45) { // Errors -
+			this.returnError(reply);
+		} else {
+			this.returnReply(reply); // Strings + // Integers : // Bulk strings $ // Arrays *
+		}
+		this.offsetCache = this.offset;
+		this.type = this.buffer[this.offset++];
+		reply = this.tryParsing();
+	}
+	if (this.type !== undefined) {
+		// Reset the buffer so the parser can handle following commands properly
+		this.buffer = new Buffer(0);
+		this.returnFatalError(new Error('Protocol error, got ' + JSON.stringify(String.fromCharCode(this.type)) + ' as reply type byte'));
+	}
+};
+
+JavascriptReplyParser.prototype.parseHeader = function () {
+	var end   = this.packetEndOffset(),
+		value = this.buffer.toString('ascii', this.offset, end) | 0;
+
+	this.offset = end + 2;
+	return value;
+};
+
+JavascriptReplyParser.prototype.packetEndOffset = function () {
+	var offset = this.offset,
+		len = this.buffer.length - 1;
+
+	while (this.buffer[offset] !== 0x0d && this.buffer[offset + 1] !== 0x0a) {
+		offset++;
+
+		if (offset >= len) {
+			throw new Error('Did not see LF after NL reading multi bulk count (' + offset + ' => ' + this.buffer.length + ', ' + this.offset + ')');
+		}
+	}
+	return offset;
+};
+
+module.exports = JavascriptReplyParser;

--- a/benchmark/old/parser.js
+++ b/benchmark/old/parser.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var parsers = {
+	javascript: require('./javascript')
+};
+
+// Hiredis might not be installed
+try {
+	parsers.hiredis = require('./hiredis');
+} catch (err) { /* ignore errors */ }
+
+function Parser (options) {
+	var parser, msg;
+
+	if (
+		!options ||
+		typeof options.returnError !== 'function' ||
+		typeof options.returnReply !== 'function'
+	) {
+		throw new Error('Please provide all return functions while initiating the parser');
+	}
+
+	if (options.name === 'hiredis') {
+		/* istanbul ignore if: hiredis should always be installed while testing */
+		if (!parsers.hiredis) {
+			msg = 'You explicitly required the hiredis parser but hiredis is not installed. The JS parser is going to be returned instead.';
+		} else if (options.stringNumbers) {
+			msg = 'You explicitly required the hiredis parser in combination with the stringNumbers option. Only the JS parser can handle that and is choosen instead.';
+		}
+	} else if (options.name && !parsers[options.name] && options.name !== 'auto') {
+		msg = 'The requested parser "' + options.name + '" is unkown and the default parser is choosen instead.';
+	}
+
+	if (msg) {
+		console.warn(new Error(msg).stack.replace('Error: ', 'Warning: '));
+	}
+
+	options.name = options.name || 'hiredis';
+	options.name = options.name.toLowerCase();
+
+	var innerOptions = {
+		// The hiredis parser expects underscores
+		return_buffers: options.returnBuffers || false,
+		string_numbers: options.stringNumbers || false
+	};
+
+	if (options.name === 'javascript' || !parsers.hiredis || options.stringNumbers) {
+		parser = new parsers.javascript(innerOptions);
+	} else {
+		parser = new parsers.hiredis(innerOptions);
+	}
+
+	parser.returnError = options.returnError;
+	parser.returnFatalError = options.returnFatalError || options.returnError;
+	parser.returnReply = options.returnReply;
+	return parser;
+}
+
+module.exports = Parser;

--- a/lib/hiredis.js
+++ b/lib/hiredis.js
@@ -2,35 +2,45 @@
 
 var hiredis = require('hiredis');
 
-function HiredisReplyParser(options) {
-    this.name = 'hiredis';
-    this.options = options;
-    this.reader = new hiredis.Reader(options);
+/**
+ * Parse data 
+ * @param parser
+ * @returns {*}
+ */
+function parseData(parser) {
+	try {
+		return parser.reader.get();
+	} catch (err) {
+		// Protocol errors land here
+		// Reset the parser. Otherwise new commands can't be processed properly
+		parser.reader = new hiredis.Reader(parser.options);
+		parser.returnFatalError(err);
+	}
 }
 
-HiredisReplyParser.prototype.parseData = function () {
-    try {
-        return this.reader.get();
-    } catch (err) {
-        // Protocol errors land here
-        // Reset the parser. Otherwise new commands can't be processed properly
-        this.reader = new hiredis.Reader(this.options);
-        this.returnFatalError(err);
-    }
-};
+/**
+ * Hiredis Parser
+ * @param options
+ * @constructor
+ */
+function HiredisReplyParser(options) {
+	this.name = 'hiredis';
+	this.options = options;
+	this.reader = new hiredis.Reader(options);
+}
 
 HiredisReplyParser.prototype.execute = function (data) {
-    this.reader.feed(data);
-    var reply = this.parseData();
+	this.reader.feed(data);
+	var reply = parseData(this);
 
-    while (reply !== undefined) {
-        if (reply && reply.name === 'Error') {
-            this.returnError(reply);
-        } else {
-            this.returnReply(reply);
-        }
-        reply = this.parseData();
-    }
+	while (reply !== undefined) {
+		if (reply && reply.name === 'Error') {
+			this.returnError(reply);
+		} else {
+			this.returnReply(reply);
+		}
+		reply = parseData(this);
+	}
 };
 
 module.exports = HiredisReplyParser;

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -1,172 +1,262 @@
 'use strict';
+/*jshint latedef: nofunc */
 
-function JavascriptReplyParser(options) {
-    this.name = 'javascript';
-    this.buffer = new Buffer(0);
-    this.offset = 0;
-    this.bigStrSize = 0;
-    this.chunksSize = 0;
-    this.buffers = [];
-    this.type = 0;
-    this.protocolError = false;
-    this.offsetCache = 0;
-    // If returnBuffers is active, all return values are returned as buffers besides numbers and errors
-    if (options.return_buffers) {
-        this.handleReply = function (start, end) {
-            return this.buffer.slice(start, end);
-        };
-    } else {
-        this.handleReply = function (start, end) {
-            return this.buffer.toString('utf-8', start, end);
-        };
-    }
-    // If stringNumbers is activated the parser always returns numbers as string
-    // This is important for big numbers (number > Math.pow(2, 53)) as js numbers are 64bit floating point numbers with reduced precision
-    if (options.string_numbers) {
-        this.handleNumbers = function (start, end) {
-            return this.buffer.toString('ascii', start, end);
-        };
-    } else {
-        this.handleNumbers = function (start, end) {
-            return +this.buffer.toString('ascii', start, end);
-        };
-    }
+/**
+ * Used for lengths only, faster perf on arrays / bulks
+ * @param parser
+ * @returns {*}
+ */
+function parseSimpleString(parser) {
+	var offset = parser.offset;
+	var length = parser.buffer.length;
+	var string = '';
+
+	while (offset < length) {
+		var c1 = parser.buffer[offset++];
+		if (c1 === 13) {
+			var c2 = parser.buffer[offset++];
+			if (c2 === 10) {
+				parser.offset = offset;
+				return string;
+			}
+			string += String.fromCharCode(c1) + String.fromCharCode(c2);
+			continue;
+		}
+		string += String.fromCharCode(c1);
+	}
+	return undefined;
 }
 
-JavascriptReplyParser.prototype.parseResult = function (type) {
-    var start = 0,
-        end = 0,
-        packetHeader = 0,
-        reply;
+/**
+ * Returns a string or buffer of the provided offset start and
+ * end ranges. Checks `optionReturnBuffers`.
+ * @param parser
+ * @param start
+ * @param end
+ * @returns {*}
+ */
+function convertBufferRange(parser, start, end) {
+	// If returnBuffers is active, all return values are returned as buffers besides numbers and errors
+	if (parser.optionReturnBuffers === true) {
+		return parser.buffer.slice(start, end);
+	}
 
-    if (type === 36) { // $
-        packetHeader = this.parseHeader();
-        // Packets with a size of -1 are considered null
-        if (packetHeader === -1) {
-            return null;
-        }
-        end = this.offset + packetHeader;
-        start = this.offset;
-        if (end + 2 > this.buffer.length) {
-            this.buffers.push(this.offsetCache === 0 ? this.buffer : this.buffer.slice(this.offsetCache));
-            this.chunksSize = this.buffers[0].length;
-            // Include the packetHeader delimiter
-            this.bigStrSize = packetHeader + 2;
-            throw new Error('Wait for more data.');
-        }
-        // Set the offset to after the delimiter
-        this.offset = end + 2;
-        return this.handleReply(start, end);
-    } else if (type === 58) { // :
-        // Up to the delimiter
-        end = this.packetEndOffset();
-        start = this.offset;
-        // Include the delimiter
-        this.offset = end + 2;
-        // Return the coerced numeric value
-        return this.handleNumbers(start, end);
-    } else if (type === 43) { // +
-        end = this.packetEndOffset();
-        start = this.offset;
-        this.offset = end + 2;
-        return this.handleReply(start, end);
-    } else if (type === 42) { // *
-        packetHeader = this.parseHeader();
-        if (packetHeader === -1) {
-            return null;
-        }
-        reply = [];
-        for (var i = 0; i < packetHeader; i++) {
-            if (this.offset >= this.buffer.length) {
-                throw new Error('Wait for more data.');
-            }
-            reply.push(this.parseResult(this.buffer[this.offset++]));
-        }
-        return reply;
-    } else if (type === 45) { // -
-        end = this.packetEndOffset();
-        start = this.offset;
-        this.offset = end + 2;
-        return new Error(this.buffer.toString('utf-8', start, end));
-    }
+	return parser.buffer.toString('utf-8', start, end);
+}
+
+/**
+ * Parse a '+' redis simple string response but forward the offsets
+ * onto convertBufferRange to generate a string.
+ * @param parser
+ * @returns {*}
+ */
+function parseSimpleStringViaOffset(parser) {
+	var start = parser.offset;
+	var offset = parser.offset;
+	var length = parser.buffer.length;
+
+	while (offset < length) {
+		var c1 = parser.buffer[offset++];
+		if (c1 === 13) { // \r
+			var c2 = parser.buffer[offset++];
+			if (c2 === 10) { // \n
+				parser.offset = offset;
+				return convertBufferRange(parser, start, offset - 2);
+			}
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Returns the string length via parseSimpleString
+ * @param parser
+ * @returns {*}
+ */
+function parseLength(parser) {
+	var string = parseSimpleString(parser);
+	if (string !== undefined) {
+		var length = +string;
+		if (length === -1) {
+			return null;
+		}
+		return length;
+	}
+}
+
+/**
+ * Parse a ':' redis integer response
+ * @param parser
+ * @returns {*}
+ */
+function parseInteger(parser) {
+	var string = parseSimpleStringViaOffset(parser);
+	if (string !== undefined) {
+		// If stringNumbers is activated the parser always returns numbers as string
+		// This is important for big numbers (number > Math.pow(2, 53)) as js numbers
+		// are 64bit floating point numbers with reduced precision
+		if (parser.optionStringNumbers === false) {
+			return +string;
+		}
+		return string;
+	}
+}
+
+/**
+ * Parse a '$' redis bulk string response
+ * @param parser
+ * @returns {null}
+ */
+function parseBulkString(parser) {
+	var length = parseLength(parser);
+	/* jshint eqnull: true */
+	if (length == null) {
+		return length;
+	}
+	var offsetEnd = parser.offset + length;
+	if ((offsetEnd + 2) > parser.buffer.length) {
+		return;
+	}
+
+	var offsetBegin = parser.offset;
+	parser.offset = offsetEnd + 2;
+
+	return convertBufferRange(parser, offsetBegin, offsetEnd);
+}
+
+/**
+ * Parse a '-' redis error response
+ * @param parser
+ * @returns {Error}
+ */
+function parseError(parser) {
+	var string = parseSimpleStringViaOffset(parser);
+	if (string !== undefined) {
+		return new Error(string);
+	}
+}
+
+/**
+ * Parsing error handler, resets parser buffer
+ * @param parser
+ * @param error
+ */
+function handleError(parser, error) {
+	parser.buffer = null;
+	parser.returnFatalError(error);
+}
+
+/**
+ * Parse a
+ * @param parser
+ * @returns {*}
+ */
+function parseArray(parser) {
+	var length = parseLength(parser);
+	/* jshint eqnull: true */
+	if (length == null) { // will break if using ===
+		return length;
+	}
+
+	var responses = new Array(length);
+	var bufferLength = parser.buffer.length;
+	for (var i = 0; i < length; i++) {
+		if (parser.offset >= bufferLength) {
+			return;
+		}
+		var response = parseType(parser, parser.buffer[parser.offset++]);
+		if (response === undefined) {
+			return;
+		}
+		responses[i] = response;
+	}
+
+	return responses;
+}
+
+/**
+ * Called the appropriate parser for the specified type.
+ * @param parser
+ * @param type
+ * @returns {*}
+ */
+function parseType(parser, type) {
+	switch (type) {
+		case 36: // $
+			return parseBulkString(parser);
+		case 58: // :
+			return parseInteger(parser);
+		case 43: // +
+			return parser.optionReturnBuffers ? parseSimpleStringViaOffset(parser) : parseSimpleString(parser);
+		case 42: // *
+			return parseArray(parser);
+		case 45: // -
+			return parseError(parser);
+		default:
+			return handleError(parser, new Error('Protocol error, got ' + JSON.stringify(String.fromCharCode(type)) + ' as reply type byte'));
+	}
+}
+
+/**
+ * Quick buffer appending via buffer copy.
+ * @param parser
+ * @param buffer
+ */
+function appendToBuffer(parser, buffer) {
+	var oldLength = parser.buffer.length;
+	var remainingLength = oldLength - parser.offset;
+	var newLength = remainingLength + buffer.length;
+	var newBuffer = new Buffer(newLength);
+	parser.buffer.copy(newBuffer, 0, parser.offset, oldLength);
+	buffer.copy(newBuffer, remainingLength, 0, buffer.length);
+	parser.buffer = newBuffer;
+	parser.offset = 0;
+}
+
+/**
+ * Javascript Redis Parser
+ * @param options
+ * @constructor
+ */
+function JavascriptRedisParser(options) {
+	this.optionReturnBuffers = !!options.return_buffers;
+	this.optionStringNumbers = !!options.string_numbers;
+	this.name = 'javascript';
+	this.offset = 0;
+	this.buffer = null;
+}
+
+/**
+ * Parse the redis buffer
+ * @param buffer
+ */
+JavascriptRedisParser.prototype.execute = function (buffer) {
+	if (this.buffer === null) {
+		this.buffer = buffer;
+		this.offset = 0;
+	} else {
+		appendToBuffer(this, buffer);
+	}
+
+	var length = this.buffer.length;
+
+	while (this.offset < length) {
+		var offset = this.offset;
+		var type = this.buffer[this.offset++];
+		var response = parseType(this, type);
+		if (response === undefined) {
+			this.offset = offset;
+			return;
+		}
+
+		if (type === 45) {
+			this.returnError(response); // Errors -
+		} else {
+			this.returnReply(response); // Strings + // Integers : // Bulk strings $ // Arrays *
+		}
+	}
+
+	this.buffer = null;
 };
 
-JavascriptReplyParser.prototype.execute = function (buffer) {
-    if (this.chunksSize !== 0) {
-        if (this.bigStrSize > this.chunksSize + buffer.length) {
-            this.buffers.push(buffer);
-            this.chunksSize += buffer.length;
-            return;
-        }
-        this.buffers.push(buffer);
-        this.buffer = Buffer.concat(this.buffers, this.chunksSize + buffer.length);
-        this.buffers = [];
-        this.bigStrSize = 0;
-        this.chunksSize = 0;
-    } else if (this.offset >= this.buffer.length) {
-        this.buffer = buffer;
-    } else {
-        this.buffer = Buffer.concat([this.buffer.slice(this.offset), buffer]);
-    }
-    this.offset = 0;
-    this.run();
-};
-
-JavascriptReplyParser.prototype.tryParsing = function () {
-    try {
-        return this.parseResult(this.type);
-    } catch (err) {
-        // Catch the error (not enough data), rewind if it's an array,
-        // and wait for the next packet to appear
-        this.offset = this.offsetCache;
-        // Indicate that there's no protocol error by resetting the type too
-        this.type = undefined;
-    }
-};
-
-JavascriptReplyParser.prototype.run = function () {
-    // Set a rewind point. If a failure occurs, wait for the next execute()/append() and try again
-    this.offsetCache = this.offset;
-    this.type = this.buffer[this.offset++];
-    var reply = this.tryParsing();
-
-    while (reply !== undefined) {
-        if (this.type === 45) { // Errors -
-            this.returnError(reply);
-        } else {
-            this.returnReply(reply); // Strings + // Integers : // Bulk strings $ // Arrays *
-        }
-        this.offsetCache = this.offset;
-        this.type = this.buffer[this.offset++];
-        reply = this.tryParsing();
-    }
-    if (this.type !== undefined) {
-        // Reset the buffer so the parser can handle following commands properly
-        this.buffer = new Buffer(0);
-        this.returnFatalError(new Error('Protocol error, got ' + JSON.stringify(String.fromCharCode(this.type)) + ' as reply type byte'));
-    }
-};
-
-JavascriptReplyParser.prototype.parseHeader = function () {
-    var end   = this.packetEndOffset(),
-        value = this.buffer.toString('ascii', this.offset, end) | 0;
-
-    this.offset = end + 2;
-    return value;
-};
-
-JavascriptReplyParser.prototype.packetEndOffset = function () {
-    var offset = this.offset,
-        len = this.buffer.length - 1;
-
-    while (this.buffer[offset] !== 0x0d && this.buffer[offset + 1] !== 0x0a) {
-        offset++;
-
-        if (offset >= len) {
-            throw new Error('Did not see LF after NL reading multi bulk count (' + offset + ' => ' + this.buffer.length + ', ' + this.offset + ')');
-        }
-    }
-    return offset;
-};
-
-module.exports = JavascriptReplyParser;
+module.exports = JavascriptRedisParser;

--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -33,11 +33,12 @@ function parseSimpleString(parser) {
  * @param parser
  * @param start
  * @param end
+ * @param noBuffer
  * @returns {*}
  */
-function convertBufferRange(parser, start, end) {
+function convertBufferRange(parser, start, end, noBuffer) {
 	// If returnBuffers is active, all return values are returned as buffers besides numbers and errors
-	if (parser.optionReturnBuffers === true) {
+	if (!noBuffer && parser.optionReturnBuffers === true) {
 		return parser.buffer.slice(start, end);
 	}
 
@@ -48,9 +49,10 @@ function convertBufferRange(parser, start, end) {
  * Parse a '+' redis simple string response but forward the offsets
  * onto convertBufferRange to generate a string.
  * @param parser
+ * @param noBuffer
  * @returns {*}
  */
-function parseSimpleStringViaOffset(parser) {
+function parseSimpleStringViaOffset(parser, noBuffer) {
 	var start = parser.offset;
 	var offset = parser.offset;
 	var length = parser.buffer.length;
@@ -61,7 +63,7 @@ function parseSimpleStringViaOffset(parser) {
 			var c2 = parser.buffer[offset++];
 			if (c2 === 10) { // \n
 				parser.offset = offset;
-				return convertBufferRange(parser, start, offset - 2);
+				return convertBufferRange(parser, start, offset - 2, noBuffer);
 			}
 		}
 	}
@@ -74,7 +76,14 @@ function parseSimpleStringViaOffset(parser) {
  * @returns {*}
  */
 function parseLength(parser) {
-	var string = parseSimpleString(parser);
+	var string;
+	/* istanbul ignore if  */
+	if (parser.buffer.length > 4096) {
+		 string = parseSimpleStringViaOffset(parser, true);
+	} else {
+		string = parseSimpleString(parser);
+	}
+	
 	if (string !== undefined) {
 		var length = +string;
 		if (length === -1) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
+    "benchmark": "node ./benchmark",
     "posttest": "jshint . && npm run coverage && npm run coverage:check",
     "coverage": "node ./node_modules/istanbul/lib/cli.js cover --preserve-comments ./node_modules/mocha/bin/_mocha -- -R spec",
     "coverage:check": "node ./node_modules/istanbul/lib/cli.js check-coverage --branch 100 --statement 100"
@@ -28,10 +29,12 @@
     "node": ">=0.10.0"
   },
   "devDependencies": {
+    "benchmark": "^2.1.0",
     "codeclimate-test-reporter": "^0.1.1",
     "intercept-stdout": "^0.1.2",
     "istanbul": "^0.4.0",
     "jshint": "^2.8.0",
+    "microtime": "^2.1.1",
     "mocha": "^2.3.2"
   },
   "optionalDependency": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,10 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.0",
-    "codeclimate-test-reporter": "^0.1.1",
+    "codeclimate-test-reporter": "^0.3.1",
     "intercept-stdout": "^0.1.2",
     "istanbul": "^0.4.0",
     "jshint": "^2.8.0",
-    "microtime": "^2.1.1",
     "mocha": "^2.3.2"
   },
   "optionalDependency": {


### PR DESCRIPTION
Re-wrote the javascript parser, averages around 14k ops/s more and ~2-3x faster parsing.

Thoughts?

## Benchmarks
![image](https://cloud.githubusercontent.com/assets/5347038/15053515/ee7b08a2-12fa-11e6-80eb-69858e749cdf.png)

Also slightly tweaked the hiredis parser also, ~1-2% change, not really noticeable but every little helps

@luin @BridgeAR tagging you both in.