### PR TITLE
v.2.0.1 proposal

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+languages:
+  JavaScript: true
+exclude_paths:
+- "benchmark/index.js"
+- "benchmark/old/javascript.js"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## v.2.0.1 - 0x Jun, 2016
+
+Bugfixes
+
+-  Fixed multiple parsers working concurrently resulting in faulty data in some cases
+
 ## v.2.0.0 - 29 May, 2016
 
 The javascript parser got completly rewritten by [Michael Diarmid](https://github.com/Salakar) and [Ruben Bridgewater](https://github.com/BridgeAR) and is now a lot faster than the hiredis parser.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -137,7 +137,6 @@ function parseBulkString (parser) {
     parser.bigStrSize = offsetEnd + 2
     parser.bigOffset = parser.offset
     parser.totalChunkSize = parser.buffer.length
-    parser.bufferCache.push(parser.buffer)
     return
   }
 
@@ -348,20 +347,20 @@ JavascriptRedisParser.prototype.execute = function (buffer) {
     this.offset = 0
   } else if (this.bigStrSize === 0) {
     var oldLength = this.buffer.length
-    var remainingLength = oldLength - this.offset
-    var newLength = remainingLength + buffer.length
+    var newLength = oldLength + buffer.length
     // ~ 5% speed increase over using new Buffer(length) all the time
     if (bufferPool.length < newLength) { // We can't rely on the chunk size
       bufferPool = new Buffer(newLength)
     }
-    this.buffer.copy(bufferPool, 0, this.offset, oldLength)
-    buffer.copy(bufferPool, remainingLength, 0, buffer.length)
+    this.buffer.copy(bufferPool, 0, 0, oldLength)
+    buffer.copy(bufferPool, oldLength, 0, buffer.length)
     this.buffer = bufferPool.slice(0, newLength)
     this.offset = 0
   } else if (this.totalChunkSize + buffer.length >= this.bigStrSize) {
+    this.bufferCache.unshift(this.buffer)
     this.bufferCache.push(buffer)
     // The returned type might be Array * (42) and in that case we can't improve the parsing currently
-    if (this.optionReturnBuffers === false && this.buffer[this.offset] === 36) {
+    if (this.optionReturnBuffers === false && this.buffer[0] === 36) {
       this.returnReply(concatBulkString(this))
       this.buffer = buffer
     } else { // This applies for arrays too
@@ -382,7 +381,18 @@ JavascriptRedisParser.prototype.execute = function (buffer) {
     var type = this.buffer[this.offset++]
     var response = parseType(this, type)
     if (response === undefined) {
-      this.offset = offset
+      if (this.buffer === null) {
+        return
+      }
+      var tempBuffer = new Buffer(this.buffer.length - offset)
+      this.buffer.copy(tempBuffer, 0, offset, this.buffer.length)
+      this.buffer = tempBuffer
+      if (this.bigStrSize !== 0) {
+        this.bigStrSize -= offset
+        this.bigOffset -= offset
+        this.totalChunkSize -= offset
+      }
+      this.offset = 0
       return
     }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -135,8 +135,6 @@ function parseBulkString (parser) {
   var offsetEnd = parser.offset + length
   if (offsetEnd + 2 > parser.buffer.length) {
     parser.bigStrSize = offsetEnd + 2
-    parser.bigOffset = parser.offset
-    parser.totalChunkSize = parser.buffer.length
     return
   }
 
@@ -333,7 +331,7 @@ function concatBuffer (parser, length) {
     list[i].copy(bufferPool, pos)
     pos += list[i].length
   }
-  return bufferPool.slice(parser.offset, length)
+  return bufferPool.slice(0, length)
 }
 
 /**
@@ -355,9 +353,7 @@ JavascriptRedisParser.prototype.execute = function (buffer) {
     this.buffer.copy(bufferPool, 0, 0, oldLength)
     buffer.copy(bufferPool, oldLength, 0, buffer.length)
     this.buffer = bufferPool.slice(0, newLength)
-    this.offset = 0
   } else if (this.totalChunkSize + buffer.length >= this.bigStrSize) {
-    this.bufferCache.unshift(this.buffer)
     this.bufferCache.push(buffer)
     // The returned type might be Array * (42) and in that case we can't improve the parsing currently
     if (this.optionReturnBuffers === false && this.buffer[0] === 36) {
@@ -365,7 +361,6 @@ JavascriptRedisParser.prototype.execute = function (buffer) {
       this.buffer = buffer
     } else { // This applies for arrays too
       this.buffer = concatBuffer(this, this.totalChunkSize + buffer.length)
-      this.offset = 0
     }
     this.bigStrSize = 0
     this.totalChunkSize = 0
@@ -389,8 +384,9 @@ JavascriptRedisParser.prototype.execute = function (buffer) {
       this.buffer = tempBuffer
       if (this.bigStrSize !== 0) {
         this.bigStrSize -= offset
-        this.bigOffset -= offset
-        this.totalChunkSize -= offset
+        this.bigOffset = this.offset - offset
+        this.totalChunkSize = this.buffer.length
+        this.bufferCache.push(this.buffer)
       }
       this.offset = 0
       return

--- a/lib/replyError.js
+++ b/lib/replyError.js
@@ -7,20 +7,17 @@ function ReplyError (message) {
   Error.stackTraceLimit = 2
   Error.captureStackTrace(this, this.constructor)
   Error.stackTraceLimit = limit
-  Object.defineProperty(this, 'name', {
-    value: 'ReplyError',
-    configurable: false,
-    enumerable: false,
-    writable: true
-  })
   Object.defineProperty(this, 'message', {
     value: message || '',
-    configurable: false,
-    enumerable: false,
     writable: true
   })
 }
 
 util.inherits(ReplyError, Error)
+
+Object.defineProperty(ReplyError.prototype, 'name', {
+  value: 'ReplyError',
+  writable: true
+})
 
 module.exports = ReplyError


### PR DESCRIPTION
The bufferPool is [not working correct](https://github.com/gosquared/redis-clustr/issues/10) currently. The issue is that slice does not copy the buffer but returns a reference only.

Using a individual bufferPool per parser is not an option, as it would increase the memory usage significantly in case someone uses many clients (there are people who reach the maximum clients limit and in such a case this would mean a huge memory usage).

Instead I'm thinking of copying the part that we need for the next chunk. @Salakar can you think of any other solution?