### PR TITLE
Implement buffer growth multiplier

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -335,10 +335,15 @@ function decreaseBufferPool () {
 function concatBuffer (parser, length) {
   var list = parser.bufferCache
   var pos = bufferOffset
+  var multiplier = 3
   length -= parser.offset
   if (bufferPool.length < length + bufferOffset) {
     // Increase the bufferPool size by three times the current needed length
-    bufferPool = new Buffer(length * 3 + bufferOffset)
+    // except when the buffer size is already larger than 256kb
+    if (length + bufferOffset >= 1024 * 256) {
+      multiplier = 1
+    }
+    bufferPool = new Buffer(length * multiplier + bufferOffset)
     bufferOffset = 0
     counter++
     pos = 0


### PR DESCRIPTION
When dealing with very large redis keys such as 328mb strings
growing the buffer by 3 is very excessive.  So if the request
is for larger than 256kb, only grow the buffer by that amount.