### PR TITLE
Only validate options that we have types for

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -248,7 +248,7 @@ function JavascriptRedisParser (options) {
     throw new TypeError('Please provide all return functions while initiating the parser')
   }
   for (var key in options) {
-    if (typeof options[key] !== optionTypes[key]) {
+    if (optionTypes[key] && typeof options[key] !== optionTypes[key]) {
       throw new TypeError('The options argument contains the property "' + key + '" that is either unkown or of a wrong type')
     }
   }


### PR DESCRIPTION
Added check to see if key exists in types, otherwise ignore it. No point checking for all types if we only care about a limited set of options.
