### PR TITLE
Fixes #12: allow extend function as optionType in JavascriptRedisParser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -234,7 +234,8 @@ var optionTypes = {
   returnReply: 'function',
   returnBuffers: 'boolean',
   stringNumbers: 'boolean',
-  name: 'string'
+  name: 'string',
+  extend: 'function'
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/NodeRedis/node-redis-parser/issues/12