### PR TITLE
remove unref as it degrades the performance.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -365,7 +365,7 @@ function concatBuffer (parser, length) {
     counter++
     pos = 0
     if (interval === null) {
-      interval = setInterval(decreaseBufferPool, 50).unref()
+      interval = setInterval(decreaseBufferPool, 50)
     }
   }
   list[0].copy(bufferPool, pos, parser.offset, list[0].length)


### PR DESCRIPTION
We deployed a change to one service, and the performance degraded over time.  Then we reverted the change, and the performance degradation was still there.  It seems impossible since we pinned all our dependencies :-)

So I used divide and conquer to find the difference, and after a few days of trying(taking a while for the degradation to show up), it turned out node-redis didn't  pin its dependencies.  It came down to this line: removing unref and the performance was as good as before, adding it back the performance would degrade over time.

https://nodejs.org/api/timers.html#timers_timeout_ref, the document actually says it will impact the performance.
> Note: Calling timeout.unref() creates an internal timer that will wake the Node.js event loop. Creating too many of these can adversely impact performance of the Node.js application.

The benchmark tests don't touch this piece of code, and I don't know enough about the code to create it.  If someone familiar with the code can create one, it should be pretty obvious.