### PR TITLE
Accept non standard input

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -393,7 +393,8 @@ function decreaseBufferPool () {
  * @param length
  * @returns {Buffer}
  */
-function concatBuffer (parser, length) {
+function concatBuffer (parser) {
+  var length = parser.totalChunkSize
   var list = parser.bufferCache
   var pos = bufferOffset
   length -= parser.offset
@@ -448,13 +449,18 @@ JavascriptRedisParser.prototype.execute = function execute (buffer) {
       this.returnReply(arr)
       this.arrayCache = null
     }
-  } else if (this.totalChunkSize + buffer.length >= this.bigStrSize) {
+  } else {
+    this.totalChunkSize += buffer.length
     this.bufferCache.push(buffer)
+    if (this.totalChunkSize < this.bigStrSize) {
+      return
+    }
     if (this.optionReturnBuffers === false && !this.arrayCache) {
+      this.totalChunkSize -= buffer.length
       this.returnReply(concatBulkString(this))
       this.buffer = buffer
     } else {
-      this.buffer = concatBuffer(this, this.totalChunkSize + buffer.length)
+      this.buffer = concatBuffer(this)
       this.offset = 0
       if (this.arrayCache) {
         arr = parseArrayChunks(this)
@@ -469,10 +475,6 @@ JavascriptRedisParser.prototype.execute = function execute (buffer) {
     }
     this.bigStrSize = 0
     this.bufferCache = []
-  } else {
-    this.bufferCache.push(buffer)
-    this.totalChunkSize += buffer.length
-    return
   }
 
   while (this.offset < this.buffer.length) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -91,7 +91,7 @@ function convertBufferRange (parser, start, end) {
     return parser.buffer.slice(start, end)
   }
 
-  return parser.buffer.toString('utf-8', start, end)
+  return parser.buffer.toString('utf8', start, end)
 }
 
 /**
@@ -152,7 +152,7 @@ function parseBulkString (parser) {
   if (length === undefined) {
     return
   }
-  if (length === -1) {
+  if (length <= -1) {
     return null
   }
   var offsetEnd = parser.offset + length
@@ -202,7 +202,7 @@ function parseArray (parser) {
   if (length === undefined) {
     return
   }
-  if (length === -1) {
+  if (length <= -1) {
     return null
   }
   var responses = new Array(length)

--- a/test/parsers.spec.js
+++ b/test/parsers.spec.js
@@ -155,6 +155,35 @@ describe('parsers', function () {
         parserOne.execute(new Buffer('tttttttttttttttttttttt\r\n'))
       })
 
+      it('weird things', function () {
+        var replyCount = 0
+        var results = [[], '', [0, null, '', 0, '', []], 9223372036854776, '☃', [1, 'OK', null]]
+        function checkReply (reply) {
+          assert.deepEqual(results[replyCount], reply)
+          replyCount++
+        }
+        var parser = newParser(checkReply)
+        parser.execute(new Buffer('*0\r\n$0\r\n\r\n*6\r\n:\r\n$-1\r\n$0\r\n\r\n:-\r\n$'))
+        assert.strictEqual(replyCount, 2)
+        parser.execute(new Buffer('\r\n\r\n*\r\n:9223372036854775\r\n$' + Buffer.byteLength('☃') + '\r\n☃\r\n'))
+        assert.strictEqual(replyCount, 5)
+        parser.execute(new Buffer('*3\r\n:1\r\n+OK\r\n$-1\r\n'))
+        assert.strictEqual(replyCount, 6)
+      })
+
+      it('weird things 2', function () {
+        var replyCount = 0
+        var results = [null, 12345, [], null, 't']
+        function checkReply (reply) {
+          assert.deepEqual(results[replyCount], reply)
+          replyCount++
+        }
+        var parser = newParser(checkReply)
+        parser.execute(new Buffer('$-5'))
+        assert.strictEqual(replyCount, 0)
+        parser.execute(new Buffer('\r\n:12345\r\n*-\r\n*-1\r\n+t\r\n'))
+      })
+
       it('returned buffers do not get mutated', function () {
         var replyCount = 0
         var results = [new Buffer('aaaaaaaaaa'), new Buffer('zzzzzzzzzz')]


### PR DESCRIPTION
The hiredis parser accepts negative length to be parsed as null in both arrays and bulk strings.