### PR TITLE
Add top level error type

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,3 +2,4 @@
 
 module.exports = require('./lib/parser')
 module.exports.ReplyError = require('./lib/replyError')
+module.exports.RedisError = require('./lib/redisError')

--- a/lib/redisError.js
+++ b/lib/redisError.js
@@ -1,0 +1,21 @@
+'use strict'
+
+var util = require('util')
+
+function RedisError (message) {
+  Error.call(this, message)
+  Error.captureStackTrace(this, this.constructor)
+  Object.defineProperty(this, 'message', {
+    value: message || '',
+    writable: true
+  })
+}
+
+util.inherits(RedisError, Error)
+
+Object.defineProperty(RedisError.prototype, 'name', {
+  value: 'RedisError',
+  writable: true
+})
+
+module.exports = RedisError

--- a/lib/replyError.js
+++ b/lib/replyError.js
@@ -1,20 +1,16 @@
 'use strict'
 
 var util = require('util')
+var RedisError = require('./redisError')
 
 function ReplyError (message, newLimit) {
   var limit = Error.stackTraceLimit
   Error.stackTraceLimit = newLimit || 2
-  Error.call(this, message)
-  Error.captureStackTrace(this, this.constructor)
+  RedisError.call(this, message)
   Error.stackTraceLimit = limit
-  Object.defineProperty(this, 'message', {
-    value: message || '',
-    writable: true
-  })
 }
 
-util.inherits(ReplyError, Error)
+util.inherits(ReplyError, RedisError)
 
 Object.defineProperty(ReplyError.prototype, 'name', {
   value: 'ReplyError',

--- a/test/parsers.spec.js
+++ b/test/parsers.spec.js
@@ -6,6 +6,7 @@ var assert = require('assert')
 var JavascriptParser = require('../')
 var HiredisParser = require('../lib/hiredis')
 var ReplyError = JavascriptParser.ReplyError
+var RedisError = JavascriptParser.RedisError
 var parsers = [HiredisParser, JavascriptParser]
 
 // Mock the not needed return functions
@@ -236,6 +237,7 @@ describe('parsers', function () {
           assert.strictEqual(typeof this.log, 'function')
           assert.strictEqual(err.message, 'Protocol error, got "a" as reply type byte')
           assert.strictEqual(err.name, 'ReplyError')
+          assert(err instanceof RedisError)
           assert(err instanceof ReplyError)
           assert(err instanceof Error)
           replyCount++


### PR DESCRIPTION
Added top level error type of RedisError.  The end goal is to have [node-redis](https://github.com/NodeRedis/node_redis/blob/master/lib/customErrors.js) only throw errors from one common base class.