### PR TITLE
Add benchmark for nested arrays

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -62,6 +62,15 @@ for (i = 0; i < arraySize; i++) {
 
 var arrayBuffer = new Buffer(array)
 
+var arrayOfArraysSize = 100
+var arrayOfArrays = '*' + arrayOfArraysSize + '\r\n'
+for (i = 0; i < arrayOfArraysSize; i++) {
+  arrayOfArrays += '$'
+  arrayOfArrays += array
+}
+
+var arrayOfArraysBuffer = new Buffer(arrayOfArrays)
+
 var bigArraySize = 1000
 var bigArrayChunks = [new Buffer('*' + bigArraySize * 2)]
 for (i = 0; i < bigArraySize; i++) {
@@ -249,6 +258,24 @@ suite.add('JS PARSER: * array', function () {
 
 suite.add('JS PARSER BUF: * array', function () {
   parserBuffer.execute(arrayBuffer)
+})
+
+// NESTED ARRAYS
+
+suite.add('\nHIREDIS: * nested array', function () {
+  parserHiRedis.execute(arrayOfArraysBuffer)
+})
+
+suite.add('HIREDIS BUF: * nested array', function () {
+  parserHiRedisBuffer.execute(arrayOfArraysBuffer)
+})
+
+suite.add('JS PARSER: * nested array', function () {
+  parser.execute(arrayOfArraysBuffer)
+})
+
+suite.add('JS PARSER BUF: * nested array', function () {
+  parserBuffer.execute(arrayOfArraysBuffer)
 })
 
 // BIG ARRAYS


### PR DESCRIPTION
In production at @altmetric, we're seeing performance regressions from < 2 seconds for a `MULTI...EXEC` block with a `SORT` to over 10 seconds using this JavaScript parser.

The issue seems to be regarding the JavaScript parser's performance handling large nested arrays which is significantly slower than hiredis.

This commit adds a benchmark for nested arrays and has the following results on Node 6.9.4 and Redis 3.2.6 running on macOS Sierra 10.12.2 on a 1.7 GHz Intel Core i7 with 8 GB of RAM:

    $ node ./benchmark
    HIREDIS: $ multiple chunks in a bulk string x 751,870 ops/sec ±1.05% (90
    runs sampled)
    HIREDIS BUF: $ multiple chunks in a bulk string x 378,039 ops/sec ±4.24%
    (75 runs sampled)
    JS PARSER: $ multiple chunks in a bulk string x 877,428 ops/sec ±1.28%
    (89 runs sampled)
    JS PARSER BUF: $ multiple chunks in a bulk string x 974,670 ops/sec
    ±2.13% (87 runs sampled)

    HIREDIS: + multiple chunks in a string x 1,492,485 ops/sec ±1.09% (90
    runs sampled)
    HIREDIS BUF: + multiple chunks in a string x 503,567 ops/sec ±7.16% (69
    runs sampled)
    JS PARSER: + multiple chunks in a string x 1,702,071 ops/sec ±1.61% (89
    runs sampled)
    JS PARSER BUF: + multiple chunks in a string x 1,701,244 ops/sec ±2.21%
    (85 runs sampled)

    HIREDIS: $ 4mb bulk string x 130 ops/sec ±2.56% (71 runs sampled)
    HIREDIS BUF: $ 4mb bulk string x 192 ops/sec ±3.54% (62 runs sampled)
    JS PARSER: $ 4mb bulk string x 961 ops/sec ±1.69% (86 runs sampled)
    JS PARSER BUF: $ 4mb bulk string x 519 ops/sec ±9.08% (57 runs sampled)

    HIREDIS: + simple string x 1,107,213 ops/sec ±90.48% (91 runs sampled)
    HIREDIS BUF: + simple string x 560,184 ops/sec ±7.19% (67 runs sampled)
    JS PARSER: + simple string x 4,373,979 ops/sec ±1.34% (88 runs sampled)
    JS PARSER BUF: + simple string x 4,789,228 ops/sec ±2.22% (85 runs
    sampled)

    HIREDIS: : integer x 1,905,121 ops/sec ±2.72% (87 runs sampled)
    JS PARSER: : integer x 14,214,940 ops/sec ±2.05% (86 runs sampled)
    JS PARSER STR: : integer x 11,177,380 ops/sec ±1.38% (89 runs sampled)

    HIREDIS: : big integer x 1,729,124 ops/sec ±1.46% (89 runs sampled)
    JS PARSER: : big integer x 7,921,758 ops/sec ±1.81% (89 runs sampled)
    JS PARSER STR: : big integer x 3,959,360 ops/sec ±2.06% (87 runs
    sampled)

    HIREDIS: * array x 40,970 ops/sec ±1.25% (92 runs sampled)
    HIREDIS BUF: * array x 7,089 ops/sec ±6.21% (61 runs sampled)
    JS PARSER: * array x 58,288 ops/sec ±8.30% (90 runs sampled)
    JS PARSER BUF: * array x 62,607 ops/sec ±1.36% (92 runs sampled)

    HIREDIS: * nested array x 285 ops/sec ±1.52% (83 runs sampled)
    HIREDIS BUF: * nested array x 61.04 ops/sec ±7.56% (55 runs sampled)
    JS PARSER: * nested array x 14.15 ops/sec ±1.81% (39 runs sampled)
    JS PARSER BUF: * nested array x 14.20 ops/sec ±2.16% (39 runs sampled)

    HIREDIS: * big array x 336 ops/sec ±1.03% (87 runs sampled)
    HIREDIS BUF: * big array x 158 ops/sec ±1.45% (56 runs sampled)
    JS PARSER: * big array x 0.40 ops/sec ±1.32% (5 runs sampled)
    JS PARSER BUF: * big array x 0.39 ops/sec ±5.06% (5 runs sampled)

    HIREDIS: - error x 104,136 ops/sec ±1.43% (90 runs sampled)
    JS PARSER: - error x 203,987 ops/sec ±1.40% (92 runs sampled)

    Fastest is JS PARSER: : integer
    Done in 239.50s.
