### PR TITLE
Update Package.json - Move hiredis to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "node": ">=4"
   },
   "dependencies": {
+    "hiredis": "^0.5.0",
     "redis-errors": "^1.0.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",
     "codeclimate-test-reporter": "^0.4.0",
-    "hiredis": "^0.5.0",
     "istanbul": "^0.4.0",
     "mocha": "^3.1.2",
     "standard": "^10.0.0"


### PR DESCRIPTION
Installing `redis-parser` with `yarn` does not install `hiredis`. I believe build is passing because we are running `npm install hiredis` in .travis.yml

Nevermind, I think it was another issue upstream. Thanks a lot for your time.