### PR TITLE
Add fields section on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "resp",
     "hiredis"
   ],
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
it avoids ship the library with tests fixtures and the rest of stuff that increment the size of the bundle and actually are oriented just for a development mode.